### PR TITLE
Change PocketBot to implement Runnable

### DIFF
--- a/src/com/github/legendofmcpe/pocketbot/android/PocketBotService.java
+++ b/src/com/github/legendofmcpe/pocketbot/android/PocketBotService.java
@@ -36,7 +36,7 @@ public class PocketBotService extends Service{
 				PocketBot bot = new PocketBot(name, fullAddress,
 						new Console(this), new MLang(this),
 						username, new Random().nextLong());
-				bot.start();
+				new Thread(bot).start();
 				bots.put(name, bot);
 			}
 			catch(UnknownHostException e){


### PR DESCRIPTION
This is a change to the android branch to reflect that PocketBot no longer extends Thread, but implements Runnable.
